### PR TITLE
tagged pdf support

### DIFF
--- a/examples/parse_tagged_tables.rs
+++ b/examples/parse_tagged_tables.rs
@@ -3,7 +3,7 @@ use pdfium::*;
 fn print_tree(
     element: &PdfiumStructElement,
     text_page: &PdfiumTextPage,
-    objects: &Vec<PdfiumPageObject>,
+    objects: &[PdfiumPageObject],
     indent: usize,
 ) {
     let tag_type = element
@@ -15,10 +15,17 @@ fn print_tree(
     let mut text_content = String::new();
     let _mcid = element.marked_content_id();
 
-    let mcid_count = element.marked_content_id_count();
+    let mcid_count = element.marked_content_id_count().unwrap_or(0);
     let mut all_mcids = Vec::new();
     for i in 0..mcid_count {
-        all_mcids.push(element.marked_content_id_at_index(i));
+        if let Some(id) = element.marked_content_id_at_index(i) {
+            all_mcids.push(id);
+        }
+    }
+    if let Some(id) = element.marked_content_id() {
+        if !all_mcids.contains(&id) {
+            all_mcids.push(id);
+        }
     }
 
     // Check elements by mcid
@@ -64,14 +71,20 @@ fn print_tree(
 
     let child_count = element.count_children();
     for i in 0..child_count {
-        if let Ok(child) = element.get_child(i) {
+        if let Ok(child) = element.child(i) {
             print_tree(&child, text_page, objects, indent + 2);
         }
     }
 }
 
 fn main() -> PdfiumResult<()> {
-    let document = PdfiumDocument::new_from_path("TLCL-25.12.pdf", None)?;
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: parse_tagged_tables <path/to/pdf>");
+        return Ok(());
+    }
+    let path = &args[1];
+    let document = PdfiumDocument::new_from_path(path, None)?;
 
     println!("Document loaded successfully.");
     let page_count = document.pages().count();
@@ -94,7 +107,7 @@ fn main() -> PdfiumResult<()> {
                 if children_count > 0 {
                     println!("\nPage {} Structure Tree:", i + 1);
                     for j in 0..children_count {
-                        if let Ok(child) = tree.get_child(j) {
+                        if let Ok(child) = tree.child(j) {
                             print_tree(&child, &text_page, &objects, 2);
                         }
                     }

--- a/examples/parse_tagged_tables.rs
+++ b/examples/parse_tagged_tables.rs
@@ -84,10 +84,8 @@ fn main() -> PdfiumResult<()> {
             let text_page = page.text()?;
 
             let mut objects = Vec::new();
-            for obj in page.objects() {
-                if let Ok(obj) = obj {
-                    objects.push(obj);
-                }
+            for obj in page.objects().flatten() {
+                objects.push(obj);
             }
 
             if let Some(tree) = page.struct_tree() {

--- a/examples/parse_tagged_tables.rs
+++ b/examples/parse_tagged_tables.rs
@@ -1,0 +1,113 @@
+use pdfium::*;
+
+fn print_tree(
+    element: &PdfiumStructElement,
+    text_page: &PdfiumTextPage,
+    objects: &Vec<PdfiumPageObject>,
+    indent: usize,
+) {
+    let tag_type = element
+        .element_type()
+        .unwrap_or_else(|| "Unknown".to_string());
+    let alt_text = element.alt_text().unwrap_or_default();
+
+    // Find associated text
+    let mut text_content = String::new();
+    let _mcid = element.marked_content_id();
+
+    let mcid_count = element.marked_content_id_count();
+    let mut all_mcids = Vec::new();
+    for i in 0..mcid_count {
+        all_mcids.push(element.marked_content_id_at_index(i));
+    }
+
+    // Check elements by mcid
+    for obj in objects {
+        let obj_mcid = obj.get_marked_content_id();
+        if obj_mcid >= 0 && all_mcids.contains(&obj_mcid) {
+            if let Some(t) = obj.get_text(text_page) {
+                text_content.push_str(&t);
+            }
+        }
+    }
+
+    let mcid_str = if all_mcids.is_empty() {
+        "".to_string()
+    } else {
+        format!(" mcids={:?}", all_mcids)
+    };
+
+    if alt_text.is_empty() {
+        if text_content.is_empty() {
+            println!("{:indent$}<{}{}>", "", tag_type, mcid_str, indent = indent);
+        } else {
+            println!(
+                "{:indent$}<{}{}>: {}",
+                "",
+                tag_type,
+                mcid_str,
+                text_content,
+                indent = indent
+            );
+        }
+    } else {
+        println!(
+            "{:indent$}<{}{} alt=\"{}\">: {}",
+            "",
+            tag_type,
+            mcid_str,
+            alt_text,
+            text_content,
+            indent = indent
+        );
+    }
+
+    let child_count = element.count_children();
+    for i in 0..child_count {
+        if let Ok(child) = element.get_child(i) {
+            print_tree(&child, text_page, objects, indent + 2);
+        }
+    }
+}
+
+fn main() -> PdfiumResult<()> {
+    let document = PdfiumDocument::new_from_path("TLCL-25.12.pdf", None)?;
+
+    println!("Document loaded successfully.");
+    let page_count = document.pages().count();
+    println!("Total pages: {}", page_count);
+
+    // Let's just check the first 20 pages or so to see if tables/lists show up
+    for i in 0..page_count {
+        let page_result = document.page(i as i32);
+        if let Ok(page) = page_result {
+            let text_page = page.text()?;
+
+            let mut objects = Vec::new();
+            for obj in page.objects() {
+                if let Ok(obj) = obj {
+                    objects.push(obj);
+                }
+            }
+
+            if let Some(tree) = page.struct_tree() {
+                let children_count = tree.count_children();
+
+                if children_count > 0 {
+                    println!("\nPage {} Structure Tree:", i + 1);
+                    for j in 0..children_count {
+                        if let Ok(child) = tree.get_child(j) {
+                            print_tree(&child, &text_page, &objects, 2);
+                        }
+                    }
+                }
+            }
+        }
+
+        if i > 50 {
+            break;
+        } // stop early if it's too long
+    }
+
+    Ok(())
+}

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -78,7 +78,7 @@ impl PdfiumBitmap {
     /// Returns the height of the image in the bitmap buffer backing this [`PdfiumBitmap`].
     #[inline]
     pub fn height(&self) -> i32 {
-        lib().FPDFBitmap_GetHeight(self) as i32
+        lib().FPDFBitmap_GetHeight(self)
     }
 
     /// Returns the pixel format of the image in the bitmap buffer backing this [`PdfiumBitmap`].

--- a/src/bitmap/mod.rs
+++ b/src/bitmap/mod.rs
@@ -72,7 +72,7 @@ impl PdfiumBitmap {
     /// Returns the width of the image in the bitmap buffer backing this [`PdfiumBitmap`].
     #[inline]
     pub fn width(&self) -> i32 {
-        lib().FPDFBitmap_GetWidth(self) as i32
+        lib().FPDFBitmap_GetWidth(self)
     }
 
     /// Returns the height of the image in the bitmap buffer backing this [`PdfiumBitmap`].

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -93,6 +93,11 @@ impl PdfiumPage {
         }
     }
 
+    /// Gets the structural tree for this page if it has one (e.g. Tagged PDF).
+    pub fn struct_tree(&self) -> Option<crate::PdfiumStructTree> {
+        lib().FPDF_StructTree_GetForPage(self).ok()
+    }
+
     pub(crate) fn set_owner(&mut self, owner: PdfiumDocument) {
         self.owner = Some(owner);
     }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -95,7 +95,9 @@ impl PdfiumPage {
 
     /// Gets the structural tree for this page if it has one (e.g. Tagged PDF).
     pub fn struct_tree(&self) -> Option<PdfiumStructTree> {
-        lib().FPDF_StructTree_GetForPage(self).ok()
+        let mut tree = lib().FPDF_StructTree_GetForPage(self).ok()?;
+        tree.set_owner(self.clone());
+        Some(tree)
     }
 
     pub(crate) fn set_owner(&mut self, owner: PdfiumDocument) {

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -26,7 +26,7 @@ pub mod render;
 pub mod text;
 
 use crate::{
-    PdfiumDocument, PdfiumPageObject, PdfiumTextPage,
+    PdfiumDocument, PdfiumPageObject, PdfiumStructTree, PdfiumTextPage,
     error::{PdfiumError, PdfiumResult},
     lib,
     page::{boundaries::PdfiumPageBoundaries, object::objects::PdfiumPageObjects},
@@ -94,7 +94,7 @@ impl PdfiumPage {
     }
 
     /// Gets the structural tree for this page if it has one (e.g. Tagged PDF).
-    pub fn struct_tree(&self) -> Option<crate::PdfiumStructTree> {
+    pub fn struct_tree(&self) -> Option<PdfiumStructTree> {
         lib().FPDF_StructTree_GetForPage(self).ok()
     }
 

--- a/src/page/object/mod.rs
+++ b/src/page/object/mod.rs
@@ -242,7 +242,7 @@ impl PdfiumPageObject {
         let mut empty_vec = Vec::new();
         let len = lib().FPDFTextObj_GetText(self, text_page, &mut empty_vec, 0);
         if len > 0 {
-            let mut buffer = vec![0u16; len as usize];
+            let mut buffer = vec![0u16; (len as usize).div_ceil(2)];
             lib().FPDFTextObj_GetText(self, text_page, &mut buffer, len);
             if let Some(pos) = buffer.iter().position(|&c| c == 0) {
                 buffer.truncate(pos);

--- a/src/page/object/mod.rs
+++ b/src/page/object/mod.rs
@@ -23,7 +23,7 @@ pub mod objects;
 use std::{ffi::CString, os::raw::c_ulong};
 
 use crate::{
-    PdfiumClipPath, PdfiumPage, PdfiumPageObjectMark,
+    PdfiumClipPath, PdfiumPage, PdfiumPageObjectMark, PdfiumTextPage,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_constants::{
@@ -238,7 +238,7 @@ impl PdfiumPageObject {
     ///
     /// Returns the text as an `Option<String>`, or `None` if it is not a text object
     /// or if text extraction fails.
-    pub fn get_text(&self, text_page: &crate::PdfiumTextPage) -> Option<String> {
+    pub fn get_text(&self, text_page: &PdfiumTextPage) -> Option<String> {
         let mut empty_vec = Vec::new();
         let len = lib().FPDFTextObj_GetText(self, text_page, &mut empty_vec, 0);
         if len > 0 {

--- a/src/page/object/mod.rs
+++ b/src/page/object/mod.rs
@@ -232,6 +232,27 @@ impl PdfiumPageObject {
         lib().FPDFPageObj_GetMarkedContentID(self)
     }
 
+    /// Get the text from this [`PdfiumPageObject`] if it is a text object.
+    ///
+    /// text_page - the text page this object belongs to.
+    ///
+    /// Returns the text as an `Option<String>`, or `None` if it is not a text object
+    /// or if text extraction fails.
+    pub fn get_text(&self, text_page: &crate::PdfiumTextPage) -> Option<String> {
+        let mut empty_vec = Vec::new();
+        let len = lib().FPDFTextObj_GetText(self, text_page, &mut empty_vec, 0);
+        if len > 0 {
+            let mut buffer = vec![0u16; len as usize];
+            lib().FPDFTextObj_GetText(self, text_page, &mut buffer, len);
+            if let Some(pos) = buffer.iter().position(|&c| c == 0) {
+                buffer.truncate(pos);
+            }
+            Some(String::from_utf16_lossy(&buffer))
+        } else {
+            None
+        }
+    }
+
     /// Get the transform matrix of this [`PdfiumPageObject`].
     ///
     /// page_object - handle to this [`PdfiumPageObject`].

--- a/src/page/object/objects.rs
+++ b/src/page/object/objects.rs
@@ -140,7 +140,7 @@ mod tests {
 
     #[test]
     fn test_get_text_mcid() {
-        let document = PdfiumDocument::new_from_path("resources/test-toc.pdf", None).unwrap();
+        let document = PdfiumDocument::new_from_path("resources/groningen.pdf", None).unwrap();
         let page = document.page(0).unwrap();
         let text_page = page.text().unwrap();
 

--- a/src/page/object/objects.rs
+++ b/src/page/object/objects.rs
@@ -114,4 +114,27 @@ mod tests {
         assert_eq!(objects.object_count(), 721);
         assert_eq!(objects.count(), 720); // remaining in iterator
     }
+
+    #[test]
+    fn test_get_text() {
+        let document = PdfiumDocument::new_from_path("resources/groningen.pdf", None).unwrap();
+        let page = document.page(0).unwrap();
+        let text_page = page.text().unwrap();
+
+        let mut objects = page.objects();
+        let mut found_text = false;
+
+        for object in objects {
+            let object = object.unwrap();
+            if object.get_type() == crate::page::object::ObjectType::Text {
+                if let Some(text) = object.get_text(&text_page) {
+                    found_text = true;
+                    assert!(!text.is_empty());
+                    break;
+                }
+            }
+        }
+
+        assert!(found_text);
+    }
 }

--- a/src/page/object/objects.rs
+++ b/src/page/object/objects.rs
@@ -137,4 +137,45 @@ mod tests {
 
         assert!(found_text);
     }
+
+    #[test]
+    fn test_get_text_mcid() {
+        let document = PdfiumDocument::new_from_path("resources/test-toc.pdf", None).unwrap();
+        let page = document.page(0).unwrap();
+        let text_page = page.text().unwrap();
+
+        let mut all_mcids = Vec::new();
+        if let Some(tree) = page.struct_tree() {
+            let children = tree.count_children();
+            for i in 0..children {
+                if let Ok(child) = tree.child(i) {
+                    let mcid_count = child.marked_content_id_count().unwrap_or(0);
+                    for j in 0..mcid_count {
+                        if let Some(mcid) = child.marked_content_id_at_index(j) {
+                            all_mcids.push(mcid);
+                        }
+                    }
+                    if let Some(mcid) = child.marked_content_id() {
+                        all_mcids.push(mcid);
+                    }
+                }
+            }
+        }
+
+        let mut found_text = false;
+        for object in page.objects() {
+            let object = object.unwrap();
+            let obj_mcid = object.get_marked_content_id();
+
+            if obj_mcid >= 0 {
+                if let Some(text) = object.get_text(&text_page) {
+                    found_text = true;
+                    assert!(!text.is_empty());
+                    break;
+                }
+            }
+        }
+
+        assert!(found_text, "Should find text associated with an MCID");
+    }
 }

--- a/src/page/object/objects.rs
+++ b/src/page/object/objects.rs
@@ -121,7 +121,7 @@ mod tests {
         let page = document.page(0).unwrap();
         let text_page = page.text().unwrap();
 
-        let mut objects = page.objects();
+        let objects = page.objects();
         let mut found_text = false;
 
         for object in objects {

--- a/src/struct_element.rs
+++ b/src/struct_element.rs
@@ -56,14 +56,14 @@ impl PdfiumStructElement {
         if len > 0 {
             let mut buffer = vec![0u8; len as usize];
             lib().FPDF_StructElement_GetType(self, Some(&mut buffer), len);
-            
+
             // FPDF_StructElement_GetType returns UTF-16LE, NUL-terminated
             let u16_buffer: Vec<u16> = buffer
                 .chunks_exact(2)
                 .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
                 .take_while(|&c| c != 0)
                 .collect();
-                
+
             Some(String::from_utf16_lossy(&u16_buffer))
         } else {
             None
@@ -76,13 +76,13 @@ impl PdfiumStructElement {
         if len > 0 {
             let mut buffer = vec![0u8; len as usize];
             lib().FPDF_StructElement_GetActualText(self, Some(&mut buffer), len);
-            
+
             let u16_buffer: Vec<u16> = buffer
                 .chunks_exact(2)
                 .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
                 .take_while(|&c| c != 0)
                 .collect();
-                
+
             Some(String::from_utf16_lossy(&u16_buffer))
         } else {
             None
@@ -95,17 +95,148 @@ impl PdfiumStructElement {
         if len > 0 {
             let mut buffer = vec![0u8; len as usize];
             lib().FPDF_StructElement_GetAltText(self, Some(&mut buffer), len);
-            
+
             let u16_buffer: Vec<u16> = buffer
                 .chunks_exact(2)
                 .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
                 .take_while(|&c| c != 0)
                 .collect();
-                
+
             Some(String::from_utf16_lossy(&u16_buffer))
         } else {
             None
         }
+    }
+
+    /// Returns the title (/T) for this element.
+    pub fn title(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetTitle(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetTitle(self, Some(&mut buffer), len);
+
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the ID for this element.
+    pub fn id(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetID(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetID(self, Some(&mut buffer), len);
+
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the language code for this element.
+    pub fn lang(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetLang(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetLang(self, Some(&mut buffer), len);
+
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the object type for this element.
+    pub fn obj_type(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetObjType(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetObjType(self, Some(&mut buffer), len);
+
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the string attribute for this element.
+    pub fn string_attribute(&self, attr_name: &str) -> Option<String> {
+        let c_attr_name = std::ffi::CString::new(attr_name).ok()?;
+        let len = lib().FPDF_StructElement_GetStringAttribute(self, &c_attr_name, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetStringAttribute(self, &c_attr_name, Some(&mut buffer), len);
+
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the marked content ID for this element.
+    pub fn marked_content_id(&self) -> i32 {
+        lib().FPDF_StructElement_GetMarkedContentID(self)
+    }
+
+    /// Returns the number of marked content IDs for this element.
+    pub fn marked_content_id_count(&self) -> i32 {
+        lib().FPDF_StructElement_GetMarkedContentIdCount(self)
+    }
+
+    /// Returns the marked content ID at the given index.
+    pub fn marked_content_id_at_index(&self, index: i32) -> i32 {
+        lib().FPDF_StructElement_GetMarkedContentIdAtIndex(self, index)
+    }
+
+    /// Returns the child marked content ID at the given index.
+    pub fn child_marked_content_id(&self, index: i32) -> i32 {
+        lib().FPDF_StructElement_GetChildMarkedContentID(self, index)
+    }
+
+    /// Returns the parent of this element.
+    pub fn parent(&self) -> PdfiumResult<PdfiumStructElement> {
+        lib().FPDF_StructElement_GetParent(self)
+    }
+
+    /// Returns the number of attributes for this element.
+    pub fn attribute_count(&self) -> i32 {
+        lib().FPDF_StructElement_GetAttributeCount(self)
+    }
+
+    /// Returns the attribute at the given index.
+    pub fn attribute_at_index(&self, index: i32) -> PdfiumResult<crate::PdfiumStructElementAttr> {
+        lib().FPDF_StructElement_GetAttributeAtIndex(self, index)
     }
 }
 

--- a/src/struct_element.rs
+++ b/src/struct_element.rs
@@ -37,7 +37,7 @@ impl PdfiumStructElement {
             Err(PdfiumError::NullHandle)
         } else {
             Ok(Self {
-                handle: Handle::new(handle, None), // TODO: check close is not needed
+                handle: Handle::new(handle, None),
                 owner: None,
             })
         }
@@ -53,7 +53,7 @@ impl PdfiumStructElement {
     }
 
     /// Returns the child element at the given index.
-    pub fn get_child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
+    pub fn child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
         let mut child = lib().FPDF_StructElement_GetChildAtIndex(self, index)?;
         if let Some(owner) = &self.owner {
             child.set_owner(owner.clone());
@@ -216,32 +216,40 @@ impl PdfiumStructElement {
     }
 
     /// Returns the marked content ID for this element.
-    pub fn marked_content_id(&self) -> i32 {
-        lib().FPDF_StructElement_GetMarkedContentID(self)
+    pub fn marked_content_id(&self) -> Option<i32> {
+        let id = lib().FPDF_StructElement_GetMarkedContentID(self);
+        if id == -1 { None } else { Some(id) }
     }
 
     /// Returns the number of marked content IDs for this element.
-    pub fn marked_content_id_count(&self) -> i32 {
-        lib().FPDF_StructElement_GetMarkedContentIdCount(self)
+    pub fn marked_content_id_count(&self) -> Option<usize> {
+        let count = lib().FPDF_StructElement_GetMarkedContentIdCount(self);
+        if count == -1 {
+            None
+        } else {
+            Some(count as usize)
+        }
     }
 
     /// Returns the marked content ID at the given index.
-    pub fn marked_content_id_at_index(&self, index: i32) -> i32 {
-        lib().FPDF_StructElement_GetMarkedContentIdAtIndex(self, index)
+    pub fn marked_content_id_at_index(&self, index: usize) -> Option<i32> {
+        let id = lib().FPDF_StructElement_GetMarkedContentIdAtIndex(self, index as i32);
+        if id == -1 { None } else { Some(id) }
     }
 
     /// Returns the child marked content ID at the given index.
-    pub fn child_marked_content_id(&self, index: i32) -> i32 {
-        lib().FPDF_StructElement_GetChildMarkedContentID(self, index)
+    pub fn child_marked_content_id(&self, index: i32) -> Option<i32> {
+        let id = lib().FPDF_StructElement_GetChildMarkedContentID(self, index);
+        if id == -1 { None } else { Some(id) }
     }
 
     /// Returns the parent of this element.
-    pub fn parent(&self) -> PdfiumResult<PdfiumStructElement> {
-        let mut parent = lib().FPDF_StructElement_GetParent(self)?;
+    pub fn parent(&self) -> Option<PdfiumStructElement> {
+        let mut parent = lib().FPDF_StructElement_GetParent(self).ok()?;
         if let Some(owner) = &self.owner {
             parent.set_owner(owner.clone());
         }
-        Ok(parent)
+        Some(parent)
     }
 
     /// Returns the number of attributes for this element.

--- a/src/struct_element.rs
+++ b/src/struct_element.rs
@@ -18,6 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    PdfiumStructElementAttr,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTELEMENT, Handle, StructElementHandle},
@@ -235,7 +236,7 @@ impl PdfiumStructElement {
     }
 
     /// Returns the attribute at the given index.
-    pub fn attribute_at_index(&self, index: i32) -> PdfiumResult<crate::PdfiumStructElementAttr> {
+    pub fn attribute_at_index(&self, index: i32) -> PdfiumResult<PdfiumStructElementAttr> {
         lib().FPDF_StructElement_GetAttributeAtIndex(self, index)
     }
 }

--- a/src/struct_element.rs
+++ b/src/struct_element.rs
@@ -18,7 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    PdfiumStructElementAttr,
+    PdfiumStructElementAttr, PdfiumStructTree,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTELEMENT, Handle, StructElementHandle},
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct PdfiumStructElement {
     handle: StructElementHandle,
+    owner: Option<PdfiumStructTree>,
 }
 
 impl PdfiumStructElement {
@@ -37,8 +38,13 @@ impl PdfiumStructElement {
         } else {
             Ok(Self {
                 handle: Handle::new(handle, None), // TODO: check close is not needed
+                owner: None,
             })
         }
+    }
+
+    pub(crate) fn set_owner(&mut self, owner: PdfiumStructTree) {
+        self.owner = Some(owner);
     }
 
     /// Returns the number of children for this structure element.
@@ -48,7 +54,11 @@ impl PdfiumStructElement {
 
     /// Returns the child element at the given index.
     pub fn get_child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
-        lib().FPDF_StructElement_GetChildAtIndex(self, index)
+        let mut child = lib().FPDF_StructElement_GetChildAtIndex(self, index)?;
+        if let Some(owner) = &self.owner {
+            child.set_owner(owner.clone());
+        }
+        Ok(child)
     }
 
     /// Returns the type (/S) for this element as a String (e.g. "H1", "P", "Sect").
@@ -227,7 +237,11 @@ impl PdfiumStructElement {
 
     /// Returns the parent of this element.
     pub fn parent(&self) -> PdfiumResult<PdfiumStructElement> {
-        lib().FPDF_StructElement_GetParent(self)
+        let mut parent = lib().FPDF_StructElement_GetParent(self)?;
+        if let Some(owner) = &self.owner {
+            parent.set_owner(owner.clone());
+        }
+        Ok(parent)
     }
 
     /// Returns the number of attributes for this element.
@@ -237,7 +251,9 @@ impl PdfiumStructElement {
 
     /// Returns the attribute at the given index.
     pub fn attribute_at_index(&self, index: i32) -> PdfiumResult<PdfiumStructElementAttr> {
-        lib().FPDF_StructElement_GetAttributeAtIndex(self, index)
+        let mut attr = lib().FPDF_StructElement_GetAttributeAtIndex(self, index)?;
+        attr.set_owner(self.clone());
+        Ok(attr)
     }
 }
 

--- a/src/struct_element.rs
+++ b/src/struct_element.rs
@@ -19,6 +19,7 @@
 
 use crate::{
     error::{PdfiumError, PdfiumResult},
+    lib,
     pdfium_types::{FPDF_STRUCTELEMENT, Handle, StructElementHandle},
 };
 
@@ -36,6 +37,74 @@ impl PdfiumStructElement {
             Ok(Self {
                 handle: Handle::new(handle, None), // TODO: check close is not needed
             })
+        }
+    }
+
+    /// Returns the number of children for this structure element.
+    pub fn count_children(&self) -> i32 {
+        lib().FPDF_StructElement_CountChildren(self)
+    }
+
+    /// Returns the child element at the given index.
+    pub fn get_child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
+        lib().FPDF_StructElement_GetChildAtIndex(self, index)
+    }
+
+    /// Returns the type (/S) for this element as a String (e.g. "H1", "P", "Sect").
+    pub fn element_type(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetType(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetType(self, Some(&mut buffer), len);
+            
+            // FPDF_StructElement_GetType returns UTF-16LE, NUL-terminated
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+                
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the actual text for this element.
+    pub fn actual_text(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetActualText(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetActualText(self, Some(&mut buffer), len);
+            
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+                
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
+        }
+    }
+
+    /// Returns the alternate text for this element.
+    pub fn alt_text(&self) -> Option<String> {
+        let len = lib().FPDF_StructElement_GetAltText(self, None, 0);
+        if len > 0 {
+            let mut buffer = vec![0u8; len as usize];
+            lib().FPDF_StructElement_GetAltText(self, Some(&mut buffer), len);
+            
+            let u16_buffer: Vec<u16> = buffer
+                .chunks_exact(2)
+                .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                .take_while(|&c| c != 0)
+                .collect();
+                
+            Some(String::from_utf16_lossy(&u16_buffer))
+        } else {
+            None
         }
     }
 }

--- a/src/struct_element_attr.rs
+++ b/src/struct_element_attr.rs
@@ -19,6 +19,7 @@
 
 use crate::{
     error::{PdfiumError, PdfiumResult},
+    lib,
     pdfium_types::{FPDF_STRUCTELEMENT_ATTR, Handle, StructElementAttrHandle},
 };
 
@@ -37,6 +38,38 @@ impl PdfiumStructElementAttr {
                 handle: Handle::new_const(handle), // TODO: check close is not needed
             })
         }
+    }
+
+    /// Returns the number of attributes in this map.
+    pub fn count(&self) -> i32 {
+        lib().FPDF_StructElement_Attr_GetCount(self)
+    }
+
+    /// Returns the name of the attribute at the given index.
+    pub fn name(&self, index: i32) -> Option<String> {
+        let mut len: std::os::raw::c_ulong = 0;
+        if lib()
+            .FPDF_StructElement_Attr_GetName(self, index, None, 0, &mut len)
+            .is_ok()
+            && len > 0
+        {
+            let mut buffer = vec![0u8; len as usize];
+            if lib()
+                .FPDF_StructElement_Attr_GetName(self, index, Some(&mut buffer), len, &mut len)
+                .is_ok()
+            {
+                let end = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
+                return Some(String::from_utf8_lossy(&buffer[..end]).into_owned());
+            }
+        }
+        None
+    }
+
+    /// Returns the value for the attribute with the given name.
+    pub fn value(&self, name: &str) -> PdfiumResult<crate::PdfiumStructElementAttrValue> {
+        let c_name =
+            std::ffi::CString::new(name).map_err(|_| crate::error::PdfiumError::Unknown)?;
+        lib().FPDF_StructElement_Attr_GetValue(self, &c_name)
     }
 }
 

--- a/src/struct_element_attr.rs
+++ b/src/struct_element_attr.rs
@@ -18,6 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    PdfiumStructElementAttrValue,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTELEMENT_ATTR, Handle, StructElementAttrHandle},
@@ -66,9 +67,8 @@ impl PdfiumStructElementAttr {
     }
 
     /// Returns the value for the attribute with the given name.
-    pub fn value(&self, name: &str) -> PdfiumResult<crate::PdfiumStructElementAttrValue> {
-        let c_name =
-            std::ffi::CString::new(name).map_err(|_| crate::error::PdfiumError::Unknown)?;
+    pub fn value(&self, name: &str) -> PdfiumResult<PdfiumStructElementAttrValue> {
+        let c_name = std::ffi::CString::new(name).map_err(|_| PdfiumError::Unknown)?;
         lib().FPDF_StructElement_Attr_GetValue(self, &c_name)
     }
 }

--- a/src/struct_element_attr.rs
+++ b/src/struct_element_attr.rs
@@ -18,7 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    PdfiumStructElementAttrValue,
+    PdfiumStructElement, PdfiumStructElementAttrValue,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTELEMENT_ATTR, Handle, StructElementAttrHandle},
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct PdfiumStructElementAttr {
     handle: StructElementAttrHandle,
+    owner: Option<PdfiumStructElement>,
 }
 
 impl PdfiumStructElementAttr {
@@ -37,8 +38,13 @@ impl PdfiumStructElementAttr {
         } else {
             Ok(Self {
                 handle: Handle::new_const(handle), // TODO: check close is not needed
+                owner: None,
             })
         }
+    }
+
+    pub(crate) fn set_owner(&mut self, owner: PdfiumStructElement) {
+        self.owner = Some(owner);
     }
 
     /// Returns the number of attributes in this map.
@@ -69,7 +75,9 @@ impl PdfiumStructElementAttr {
     /// Returns the value for the attribute with the given name.
     pub fn value(&self, name: &str) -> PdfiumResult<PdfiumStructElementAttrValue> {
         let c_name = std::ffi::CString::new(name).map_err(|_| PdfiumError::Unknown)?;
-        lib().FPDF_StructElement_Attr_GetValue(self, &c_name)
+        let mut val = lib().FPDF_StructElement_Attr_GetValue(self, &c_name)?;
+        val.set_owner(self.clone());
+        Ok(val)
     }
 }
 

--- a/src/struct_element_attr.rs
+++ b/src/struct_element_attr.rs
@@ -37,7 +37,7 @@ impl PdfiumStructElementAttr {
             Err(PdfiumError::NullHandle)
         } else {
             Ok(Self {
-                handle: Handle::new_const(handle), // TODO: check close is not needed
+                handle: Handle::new_const(handle),
                 owner: None,
             })
         }
@@ -73,11 +73,11 @@ impl PdfiumStructElementAttr {
     }
 
     /// Returns the value for the attribute with the given name.
-    pub fn value(&self, name: &str) -> PdfiumResult<PdfiumStructElementAttrValue> {
-        let c_name = std::ffi::CString::new(name).map_err(|_| PdfiumError::Unknown)?;
-        let mut val = lib().FPDF_StructElement_Attr_GetValue(self, &c_name)?;
+    pub fn value(&self, name: &str) -> Option<PdfiumStructElementAttrValue> {
+        let c_name = std::ffi::CString::new(name).ok()?;
+        let mut val = lib().FPDF_StructElement_Attr_GetValue(self, &c_name).ok()?;
         val.set_owner(self.clone());
-        Ok(val)
+        Some(val)
     }
 }
 

--- a/src/struct_element_attr_value.rs
+++ b/src/struct_element_attr_value.rs
@@ -18,6 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    PdfiumStructElementAttr,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTELEMENT_ATTR_VALUE, Handle, StructElementAttrValueHandle},
@@ -27,6 +28,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct PdfiumStructElementAttrValue {
     handle: StructElementAttrValueHandle,
+    owner: Option<PdfiumStructElementAttr>,
 }
 
 impl PdfiumStructElementAttrValue {
@@ -36,8 +38,13 @@ impl PdfiumStructElementAttrValue {
         } else {
             Ok(Self {
                 handle: Handle::new_const(handle), // TODO: check close is not needed
+                owner: None,
             })
         }
+    }
+
+    pub(crate) fn set_owner(&mut self, owner: PdfiumStructElementAttr) {
+        self.owner = Some(owner);
     }
 
     /// Returns the type of this attribute value.
@@ -121,7 +128,11 @@ impl PdfiumStructElementAttrValue {
 
     /// Returns the child at the given index.
     pub fn get_child_at_index(&self, index: i32) -> PdfiumResult<PdfiumStructElementAttrValue> {
-        lib().FPDF_StructElement_Attr_GetChildAtIndex(self, index)
+        let mut child = lib().FPDF_StructElement_Attr_GetChildAtIndex(self, index)?;
+        if let Some(owner) = &self.owner {
+            child.set_owner(owner.clone());
+        }
+        Ok(child)
     }
 }
 

--- a/src/struct_element_attr_value.rs
+++ b/src/struct_element_attr_value.rs
@@ -37,7 +37,7 @@ impl PdfiumStructElementAttrValue {
             Err(PdfiumError::NullHandle)
         } else {
             Ok(Self {
-                handle: Handle::new_const(handle), // TODO: check close is not needed
+                handle: Handle::new_const(handle),
                 owner: None,
             })
         }

--- a/src/struct_element_attr_value.rs
+++ b/src/struct_element_attr_value.rs
@@ -19,6 +19,7 @@
 
 use crate::{
     error::{PdfiumError, PdfiumResult},
+    lib,
     pdfium_types::{FPDF_STRUCTELEMENT_ATTR_VALUE, Handle, StructElementAttrValueHandle},
 };
 
@@ -37,6 +38,90 @@ impl PdfiumStructElementAttrValue {
                 handle: Handle::new_const(handle), // TODO: check close is not needed
             })
         }
+    }
+
+    /// Returns the type of this attribute value.
+    pub fn value_type(&self) -> i32 {
+        lib().FPDF_StructElement_Attr_GetType(self)
+    }
+
+    /// Returns the boolean value.
+    pub fn boolean_value(&self) -> Option<bool> {
+        let mut value = 0;
+        if lib()
+            .FPDF_StructElement_Attr_GetBooleanValue(self, &mut value)
+            .is_ok()
+        {
+            Some(value != 0)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the number value.
+    pub fn number_value(&self) -> Option<f32> {
+        let mut value = 0.0;
+        if lib()
+            .FPDF_StructElement_Attr_GetNumberValue(self, &mut value)
+            .is_ok()
+        {
+            Some(value)
+        } else {
+            None
+        }
+    }
+
+    /// Returns the string value.
+    pub fn string_value(&self) -> Option<String> {
+        let mut len: std::os::raw::c_ulong = 0;
+        if lib()
+            .FPDF_StructElement_Attr_GetStringValue(self, None, 0, &mut len)
+            .is_ok()
+            && len > 0
+        {
+            let mut buffer = vec![0u8; len as usize];
+            if lib()
+                .FPDF_StructElement_Attr_GetStringValue(self, Some(&mut buffer), len, &mut len)
+                .is_ok()
+            {
+                let u16_buffer: Vec<u16> = buffer
+                    .chunks_exact(2)
+                    .map(|chunk| u16::from_le_bytes([chunk[0], chunk[1]]))
+                    .take_while(|&c| c != 0)
+                    .collect();
+                return Some(String::from_utf16_lossy(&u16_buffer));
+            }
+        }
+        None
+    }
+
+    /// Returns the blob value.
+    pub fn blob_value(&self) -> Option<Vec<u8>> {
+        let mut len: std::os::raw::c_ulong = 0;
+        if lib()
+            .FPDF_StructElement_Attr_GetBlobValue(self, None, 0, &mut len)
+            .is_ok()
+            && len > 0
+        {
+            let mut buffer = vec![0u8; len as usize];
+            if lib()
+                .FPDF_StructElement_Attr_GetBlobValue(self, Some(&mut buffer), len, &mut len)
+                .is_ok()
+            {
+                return Some(buffer);
+            }
+        }
+        None
+    }
+
+    /// Returns the number of children for this attribute value.
+    pub fn count_children(&self) -> i32 {
+        lib().FPDF_StructElement_Attr_CountChildren(self)
+    }
+
+    /// Returns the child at the given index.
+    pub fn get_child_at_index(&self, index: i32) -> PdfiumResult<PdfiumStructElementAttrValue> {
+        lib().FPDF_StructElement_Attr_GetChildAtIndex(self, index)
     }
 }
 

--- a/src/struct_tree.rs
+++ b/src/struct_tree.rs
@@ -39,6 +39,16 @@ impl PdfiumStructTree {
             })
         }
     }
+
+    /// Returns the number of children for this structure tree.
+    pub fn count_children(&self) -> i32 {
+        lib().FPDF_StructTree_CountChildren(self)
+    }
+
+    /// Returns the child element at the given index.
+    pub fn get_child(&self, index: i32) -> PdfiumResult<crate::PdfiumStructElement> {
+        lib().FPDF_StructTree_GetChildAtIndex(self, index)
+    }
 }
 
 impl From<&PdfiumStructTree> for FPDF_STRUCTTREE {

--- a/src/struct_tree.rs
+++ b/src/struct_tree.rs
@@ -53,7 +53,7 @@ impl PdfiumStructTree {
     }
 
     /// Returns the child element at the given index.
-    pub fn get_child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
+    pub fn child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
         let mut child = lib().FPDF_StructTree_GetChildAtIndex(self, index)?;
         child.set_owner(self.clone());
         Ok(child)
@@ -76,36 +76,36 @@ mod tests {
 
     #[test]
     fn test_struct_tree() {
-        let document = PdfiumDocument::new_from_path("resources/groningen.pdf", None).unwrap();
+        let document = PdfiumDocument::new_from_path("resources/test-toc.pdf", None).unwrap();
         if let Ok(page) = document.page(0) {
             let tree = page.struct_tree();
+            assert!(tree.is_some(), "Tagged PDF should have a structure tree");
             if let Some(tree) = tree {
                 let children = tree.count_children();
-                assert!(children >= 0);
-                if children > 0 {
-                    let child = tree.get_child(0);
-                    assert!(child.is_ok());
-                    let child = child.unwrap();
+                assert!(children > 0, "Structure tree should have children");
 
-                    // Test struct element methods
-                    let _ = child.obj_type();
-                    let _ = child.title();
-                    let _ = child.id();
-                    let _ = child.lang();
-                    let _ = child.alt_text();
-                    let _ = child.actual_text();
+                let child = tree.child(0);
+                assert!(child.is_ok(), "Should be able to get the first child");
+                let child = child.unwrap();
 
-                    let attr_count = child.attribute_count();
+                // Test struct element methods
+                let _ = child.obj_type();
+                let _ = child.title();
+                let _ = child.id();
+                let _ = child.lang();
+                let _ = child.alt_text();
+                let _ = child.actual_text();
+
+                let attr_count = child.attribute_count();
+                if attr_count > 0 {
+                    let attr = child.attribute_at_index(0);
+                    assert!(attr.is_ok());
+                    let attr = attr.unwrap();
+                    let attr_count = attr.count();
+                    assert!(attr_count >= 0);
                     if attr_count > 0 {
-                        let attr = child.attribute_at_index(0);
-                        assert!(attr.is_ok());
-                        let attr = attr.unwrap();
-                        let attr_count = attr.count();
-                        assert!(attr_count >= 0);
-                        if attr_count > 0 {
-                            if let Some(name) = attr.name(0) {
-                                let _ = attr.value(&name);
-                            }
+                        if let Some(name) = attr.name(0) {
+                            let _ = attr.value(&name);
                         }
                     }
                 }

--- a/src/struct_tree.rs
+++ b/src/struct_tree.rs
@@ -76,7 +76,7 @@ mod tests {
 
     #[test]
     fn test_struct_tree() {
-        let document = PdfiumDocument::new_from_path("resources/test-toc.pdf", None).unwrap();
+        let document = PdfiumDocument::new_from_path("resources/groningen.pdf", None).unwrap();
         if let Ok(page) = document.page(0) {
             let tree = page.struct_tree();
             assert!(tree.is_some(), "Tagged PDF should have a structure tree");

--- a/src/struct_tree.rs
+++ b/src/struct_tree.rs
@@ -18,7 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
-    PdfiumStructElement,
+    PdfiumPage, PdfiumStructElement,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTTREE, Handle, StructTreeHandle},
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Debug, Clone)]
 pub struct PdfiumStructTree {
     handle: StructTreeHandle,
+    owner: Option<PdfiumPage>,
 }
 
 impl PdfiumStructTree {
@@ -37,8 +38,13 @@ impl PdfiumStructTree {
         } else {
             Ok(Self {
                 handle: Handle::new(handle, Some(close_struct_tree)),
+                owner: None,
             })
         }
+    }
+
+    pub(crate) fn set_owner(&mut self, owner: PdfiumPage) {
+        self.owner = Some(owner);
     }
 
     /// Returns the number of children for this structure tree.
@@ -48,7 +54,9 @@ impl PdfiumStructTree {
 
     /// Returns the child element at the given index.
     pub fn get_child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
-        lib().FPDF_StructTree_GetChildAtIndex(self, index)
+        let mut child = lib().FPDF_StructTree_GetChildAtIndex(self, index)?;
+        child.set_owner(self.clone());
+        Ok(child)
     }
 }
 

--- a/src/struct_tree.rs
+++ b/src/struct_tree.rs
@@ -18,6 +18,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 use crate::{
+    PdfiumStructElement,
     error::{PdfiumError, PdfiumResult},
     lib,
     pdfium_types::{FPDF_STRUCTTREE, Handle, StructTreeHandle},
@@ -46,7 +47,7 @@ impl PdfiumStructTree {
     }
 
     /// Returns the child element at the given index.
-    pub fn get_child(&self, index: i32) -> PdfiumResult<crate::PdfiumStructElement> {
+    pub fn get_child(&self, index: i32) -> PdfiumResult<PdfiumStructElement> {
         lib().FPDF_StructTree_GetChildAtIndex(self, index)
     }
 }
@@ -59,4 +60,48 @@ impl From<&PdfiumStructTree> for FPDF_STRUCTTREE {
 
 fn close_struct_tree(struct_tree: FPDF_STRUCTTREE) {
     lib().FPDF_StructTree_Close(struct_tree);
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::PdfiumDocument;
+
+    #[test]
+    fn test_struct_tree() {
+        let document = PdfiumDocument::new_from_path("resources/groningen.pdf", None).unwrap();
+        if let Ok(page) = document.page(0) {
+            let tree = page.struct_tree();
+            if let Some(tree) = tree {
+                let children = tree.count_children();
+                assert!(children >= 0);
+                if children > 0 {
+                    let child = tree.get_child(0);
+                    assert!(child.is_ok());
+                    let child = child.unwrap();
+
+                    // Test struct element methods
+                    let _ = child.obj_type();
+                    let _ = child.title();
+                    let _ = child.id();
+                    let _ = child.lang();
+                    let _ = child.alt_text();
+                    let _ = child.actual_text();
+
+                    let attr_count = child.attribute_count();
+                    if attr_count > 0 {
+                        let attr = child.attribute_at_index(0);
+                        assert!(attr.is_ok());
+                        let attr = attr.unwrap();
+                        let attr_count = attr.count();
+                        assert!(attr_count >= 0);
+                        if attr_count > 0 {
+                            if let Some(name) = attr.name(0) {
+                                let _ = attr.value(&name);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
Add Comprehensive Tagged PDF Support
This pr adds full support for reading and interpreting Tagged PDF structure trees, enabling semantic extraction of document content. It exposes high-level, safe Rust wrappers for the FPDF_StructTree and FPDF_StructElement APIs.

Key additions include:

- Implemented \PdfiumStructTree\, \PdfiumStructElement\, and \PdfiumStructElementAttr\ for traversing the logical document structure.
- Added methods to \PdfiumStructElement\ to retrieve standard attributes (like /P, /H1, /L, /Table) and accessibility properties (like Alt text, language, and IDs).
- Added \get_text()\ to \PdfiumPageObject\ to extract text content associated with a specific marked content ID (MCID).
- Enabled full attribute map parsing on struct elements, allowing access to detailed properties like list numbering styles.

This change is critical for applications like e-book readers that need to be screen-reader friendly. By parsing the structure tree, content can be presented in its correct logical reading order, rather than its visual order on the page. This allows for proper reflow of text and the correct interpretation of paragraphs, headings, lists, and tables, which is essential for accessibility.